### PR TITLE
Updated the CRON_EXPRESSION to include "cron" in prefix

### DIFF
--- a/spring-cloud-scheduler-spi-test/src/main/java/org/springframework/cloud/scheduler/spi/test/AbstractIntegrationTests.java
+++ b/spring-cloud-scheduler-spi-test/src/main/java/org/springframework/cloud/scheduler/spi/test/AbstractIntegrationTests.java
@@ -184,7 +184,7 @@ public abstract class AbstractIntegrationTests {
 		String scheduleName = "ScheduleName_" + definitionName;
 
 		this.expectedException.expect(SchedulerException.class);
-		this.expectedException.expectMessage(String.format("Failed to unschedule, schedule %s does not exist.",
+		this.expectedException.expectMessage(String.format("Failed to unschedule schedule %s does not exist.",
 				scheduleName));
 		unscheduleTestSchedule(scheduleName);
 	}

--- a/spring-cloud-scheduler-spi/src/main/java/org/springframework/cloud/scheduler/spi/core/SchedulerPropertyKeys.java
+++ b/spring-cloud-scheduler-spi/src/main/java/org/springframework/cloud/scheduler/spi/core/SchedulerPropertyKeys.java
@@ -33,6 +33,6 @@ public class SchedulerPropertyKeys {
 	/**
 	 * Scheduler cron expression property key.
 	 */
-	public static final String CRON_EXPRESSION = PREFIX + "expression";
+	public static final String CRON_EXPRESSION = CRON_PREFIX + "expression";
 
 }


### PR DESCRIPTION
CRON_EXPRESSION is now spring.cloud.scheduler.cron.expression where before it was spring.cloud.scheduler.expression.

resolves #15