### PR TITLE
Sets the scope of the assertj to test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-cloud-scheduler-parent</artifactId>
-	<version>1.0.1.BUILD-SNAPSHOT</version>
+	<version>1.0.2.BUILD-SNAPSHOT</version>
 	<groupId>org.springframework.cloud</groupId>
 	<packaging>pom</packaging>
 
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>1.3.10.RELEASE</version>
+		<version>1.3.11.RELEASE</version>
 		<relativePath />
 	</parent>
 
@@ -21,7 +21,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>1.8</java.version>
 		<maven.version>3.5.0</maven.version>
-		<spring-cloud-deployer.version>1.3.3.RELEASE</spring-cloud-deployer.version>
+		<spring-cloud-deployer.version>1.3.4.RELEASE</spring-cloud-deployer.version>
 	</properties>
 
 	<modules>

--- a/spring-cloud-scheduler-spi-test-app/pom.xml
+++ b/spring-cloud-scheduler-spi-test-app/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-scheduler-parent</artifactId>
-		<version>1.0.1.BUILD-SNAPSHOT</version>
+		<version>1.0.2.BUILD-SNAPSHOT</version>
 	</parent>
 	<artifactId>spring-cloud-scheduler-spi-test-app</artifactId>
 	<properties>

--- a/spring-cloud-scheduler-spi-test/pom.xml
+++ b/spring-cloud-scheduler-spi-test/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-scheduler-parent</artifactId>
-		<version>1.0.1.BUILD-SNAPSHOT</version>
+		<version>1.0.2.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<properties>
@@ -34,7 +34,7 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-scheduler-spi</artifactId>
-			<version>1.0.1.BUILD-SNAPSHOT</version>
+			<version>1.0.2.BUILD-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-scheduler-spi-test/src/main/java/org/springframework/cloud/scheduler/spi/test/junit/AbstractExternalResourceTestSupport.java
+++ b/spring-cloud-scheduler-spi-test/src/main/java/org/springframework/cloud/scheduler/spi/test/junit/AbstractExternalResourceTestSupport.java
@@ -14,7 +14,7 @@
  *  limitations under the License.
  */
 
-package org.springframework.cloud.scheduler.spi.junit;
+package org.springframework.cloud.scheduler.spi.test.junit;
 
 import static org.junit.Assert.fail;
 

--- a/spring-cloud-scheduler-spi-test/src/main/test/org/springframework/cloud/scheduler/spi/test/junit/ExternalResourceTestSupportTests.java
+++ b/spring-cloud-scheduler-spi-test/src/main/test/org/springframework/cloud/scheduler/spi/test/junit/ExternalResourceTestSupportTests.java
@@ -14,7 +14,7 @@
  *  limitations under the License.
  */
 
-package org.springframework.cloud.scheduler.spi.implementation;
+package org.springframework.cloud.scheduler.spi.test.junit;
 
 import org.junit.AssumptionViolatedException;
 import org.junit.Rule;
@@ -22,8 +22,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
-
-import org.springframework.cloud.scheduler.spi.junit.AbstractExternalResourceTestSupport;
 
 import static org.mockito.Mockito.mock;
 

--- a/spring-cloud-scheduler-spi/pom.xml
+++ b/spring-cloud-scheduler-spi/pom.xml
@@ -11,26 +11,13 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-scheduler-parent</artifactId>
-		<version>1.0.1.BUILD-SNAPSHOT</version>
+		<version>1.0.2.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-core</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-core</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.assertj</groupId>
-			<artifactId>assertj-core</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>


### PR DESCRIPTION
resolves #28 

Junit can not be scoped to test because of its use in: AbstractExternalResourceTestSupport