### PR TITLE
URL Cleanup

### DIFF
--- a/spring-cloud-scheduler-spi-test-app/src/main/java/org/springframework/cloud/scheduler/spi/test/app/SchedulerIntegrationTest.java
+++ b/spring-cloud-scheduler-spi-test-app/src/main/java/org/springframework/cloud/scheduler/spi/test/app/SchedulerIntegrationTest.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *          http://www.apache.org/licenses/LICENSE-2.0
+ *          https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-scheduler-spi-test-app/src/main/java/org/springframework/cloud/scheduler/spi/test/app/SchedulerIntegrationTestApplication.java
+++ b/spring-cloud-scheduler-spi-test-app/src/main/java/org/springframework/cloud/scheduler/spi/test/app/SchedulerIntegrationTestApplication.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *          http://www.apache.org/licenses/LICENSE-2.0
+ *          https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-scheduler-spi-test-app/src/main/java/org/springframework/cloud/scheduler/spi/test/app/SchedulerIntegrationTestProperties.java
+++ b/spring-cloud-scheduler-spi-test-app/src/main/java/org/springframework/cloud/scheduler/spi/test/app/SchedulerIntegrationTestProperties.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *          http://www.apache.org/licenses/LICENSE-2.0
+ *          https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-scheduler-spi-test/src/main/java/org/springframework/cloud/scheduler/spi/test/AbstractIntegrationTests.java
+++ b/spring-cloud-scheduler-spi-test/src/main/java/org/springframework/cloud/scheduler/spi/test/AbstractIntegrationTests.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *          http://www.apache.org/licenses/LICENSE-2.0
+ *          https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-scheduler-spi-test/src/main/java/org/springframework/cloud/scheduler/spi/test/EventuallyMatcher.java
+++ b/spring-cloud-scheduler-spi-test/src/main/java/org/springframework/cloud/scheduler/spi/test/EventuallyMatcher.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *          http://www.apache.org/licenses/LICENSE-2.0
+ *          https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-scheduler-spi-test/src/main/java/org/springframework/cloud/scheduler/spi/test/Timeout.java
+++ b/spring-cloud-scheduler-spi-test/src/main/java/org/springframework/cloud/scheduler/spi/test/Timeout.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *          http://www.apache.org/licenses/LICENSE-2.0
+ *          https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-scheduler-spi-test/src/main/test/org/springframework/cloud/scheduler/spi/test/TestInfrastructureTests.java
+++ b/spring-cloud-scheduler-spi-test/src/main/test/org/springframework/cloud/scheduler/spi/test/TestInfrastructureTests.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *          http://www.apache.org/licenses/LICENSE-2.0
+ *          https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-scheduler-spi/src/main/java/org/springframework/cloud/scheduler/spi/core/CreateScheduleException.java
+++ b/spring-cloud-scheduler-spi/src/main/java/org/springframework/cloud/scheduler/spi/core/CreateScheduleException.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *          http://www.apache.org/licenses/LICENSE-2.0
+ *          https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-scheduler-spi/src/main/java/org/springframework/cloud/scheduler/spi/core/ScheduleInfo.java
+++ b/spring-cloud-scheduler-spi/src/main/java/org/springframework/cloud/scheduler/spi/core/ScheduleInfo.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *          http://www.apache.org/licenses/LICENSE-2.0
+ *          https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-scheduler-spi/src/main/java/org/springframework/cloud/scheduler/spi/core/ScheduleRequest.java
+++ b/spring-cloud-scheduler-spi/src/main/java/org/springframework/cloud/scheduler/spi/core/ScheduleRequest.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *          http://www.apache.org/licenses/LICENSE-2.0
+ *          https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-scheduler-spi/src/main/java/org/springframework/cloud/scheduler/spi/core/Scheduler.java
+++ b/spring-cloud-scheduler-spi/src/main/java/org/springframework/cloud/scheduler/spi/core/Scheduler.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *          http://www.apache.org/licenses/LICENSE-2.0
+ *          https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-scheduler-spi/src/main/java/org/springframework/cloud/scheduler/spi/core/SchedulerException.java
+++ b/spring-cloud-scheduler-spi/src/main/java/org/springframework/cloud/scheduler/spi/core/SchedulerException.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *          http://www.apache.org/licenses/LICENSE-2.0
+ *          https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-scheduler-spi/src/main/java/org/springframework/cloud/scheduler/spi/core/SchedulerPropertyKeys.java
+++ b/spring-cloud-scheduler-spi/src/main/java/org/springframework/cloud/scheduler/spi/core/SchedulerPropertyKeys.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *          http://www.apache.org/licenses/LICENSE-2.0
+ *          https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-scheduler-spi/src/main/java/org/springframework/cloud/scheduler/spi/core/UnScheduleException.java
+++ b/spring-cloud-scheduler-spi/src/main/java/org/springframework/cloud/scheduler/spi/core/UnScheduleException.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *          http://www.apache.org/licenses/LICENSE-2.0
+ *          https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-scheduler-spi/src/main/java/org/springframework/cloud/scheduler/spi/junit/AbstractExternalResourceTestSupport.java
+++ b/spring-cloud-scheduler-spi/src/main/java/org/springframework/cloud/scheduler/spi/junit/AbstractExternalResourceTestSupport.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *          http://www.apache.org/licenses/LICENSE-2.0
+ *          https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-scheduler-spi/src/test/java/org/springframework/cloud/scheduler/spi/implementation/ExternalResourceTestSupportTests.java
+++ b/spring-cloud-scheduler-spi/src/test/java/org/springframework/cloud/scheduler/spi/implementation/ExternalResourceTestSupportTests.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *          http://www.apache.org/licenses/LICENSE-2.0
+ *          https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 16 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).